### PR TITLE
Bump LLVM version to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,26 @@
-FROM debian:12-slim
+FROM ubuntu:jammy
 
 RUN apt update && apt install -y \
     build-essential \
-    clang \
+    gnupg \
+    lsb-release \
     ruby \
     ruby-dev \
+    software-properties-common \
+    wget \
     && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+RUN ./llvm.sh 18
 
 ENV APP_DIR="/app"
 RUN mkdir $APP_DIR
 WORKDIR $APP_DIR
 
-ENV CC="clang"
-ENV CXX="clang++"
-ENV LDSHARED="clang -shared"
-ENV LDSHAREDXX="clang++ -shared"
+ENV CC="clang-18"
+ENV CXX="clang++-18"
+ENV LDSHARED="clang-18 -shared"
+ENV LDSHAREDXX="clang++-18 -shared"
 
 # The MAKE variable allows overwriting the make command at runtime. This forces the
 # Ruby C extension to respect ENV variables when compiling, like CC, CFLAGS, etc.


### PR DESCRIPTION
This commit changes clang installed directly from apt to clang installed by an install LLVM apt script.
It installs LLVM18 (not reproducible).

To make it work easily, it was necessary to change Debian to Ubuntu.

---
Reasoning  behind using LLVM18:
> Currently, ASAN will only work correctly when using a recent head build of LLVM/Clang - it requires this bugfix related to multithreaded fork, which is not yet in any released version. See here for instructions on how to build LLVM/Clang from source (note you will need at least the clang and compiler-rt projects enabled). Then, you will need to replace CC=clang in the instructions with an explicit path to your built Clang binary.

https://github.com/ruby/ruby/blob/master/doc/contributing/building_ruby.md#building-with-address-sanitizer