### PR TITLE
Fix #14, support for Ruby back to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Ruzzy.c_trace_branch` to `Ruzzy.trace` to simplify interface
 - Support for `clang` back to `14.0.6`, and system `clang`, e.g. from `apt` ([#12](https://github.com/trailofbits/ruzzy/pull/12))
 
+### Fixed
+
+- Support for Ruby back to `3.0.0` (Ubuntu 22.04) ([#14](https://github.com/trailofbits/ruzzy/issues/14))
+
 ## [0.6.0] - 2024-02-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Table of contents:
 
 # Installing
 
-Currently, Ruzzy only supports Linux x86-64 and AArch64/ARM64. If you'd like to run Ruzzy on a Mac or Windows, you can build the [`Dockerfile`](https://github.com/trailofbits/ruzzy/blob/main/Dockerfile) and/or use the [development environment](#developing). Ruzzy requires a recent version of `clang` (tested back to `14.0.6`), preferably the [latest release](https://github.com/llvm/llvm-project/releases).
+Currently, Ruzzy only supports Linux x86-64 and AArch64/ARM64. If you'd like to run Ruzzy on a Mac or Windows, you can build the [`Dockerfile`](https://github.com/trailofbits/ruzzy/blob/main/Dockerfile) and/or use the [development environment](#developing). Ruzzy requires a recent version of `clang` (tested back to `14.0.0`), preferably the [latest release](https://github.com/llvm/llvm-project/releases).
 
 Install Ruzzy with the following command:
 

--- a/ext/cruzzy/cruzzy.c
+++ b/ext/cruzzy/cruzzy.c
@@ -194,11 +194,11 @@ static void event_hook_branch(VALUE counter_hash, rb_trace_arg_t *tracearg) {
 
 static void enable_branch_coverage_hooks()
 {
-    // Call Coverage.setup(branches: true) to activate branch coverage hooks.
+    // Call Coverage.start(branches: true) to activate branch coverage hooks.
     // Branch coverage hooks will not be activated without this call despite
     // adding the event hooks. I suspect rb_set_coverages must be called
     // first, which initializes some global state that we do not have direct
-    // access to. Calling setup initializes coverage state here:
+    // access to. Calling start initializes coverage state here:
     // https://github.com/ruby/ruby/blob/v3_3_0/ext/coverage/coverage.c#L112-L120
     // If rb_set_coverages is not called, then rb_get_coverages returns a NULL
     // pointer, which appears to effectively disable coverage collection here:
@@ -207,7 +207,7 @@ static void enable_branch_coverage_hooks()
     VALUE coverage_mod = rb_const_get(rb_cObject, rb_intern("Coverage"));
     VALUE hash_arg = rb_hash_new();
     rb_hash_aset(hash_arg, ID2SYM(rb_intern("branches")), Qtrue);
-    rb_funcall(coverage_mod, rb_intern("setup"), 1, hash_arg);
+    rb_funcall(coverage_mod, rb_intern("start"), 1, hash_arg);
 }
 
 static VALUE c_trace(VALUE self, VALUE harness_path)


### PR DESCRIPTION
I tested this by changing the Dockerfile to use `ubuntu:22.04` and running the [example harness](https://github.com/trailofbits/ruzzy?tab=readme-ov-file#fuzzing-pure-ruby-code) and confirming that coverage still works (it finds the crash). Ubuntu 22.04 currently uses clang `14.0.0`, so we're able to say we've tested clang back a bit further now.

Originally I chose calling `setup` instead of `start` because I thought the performance characteristics would be better. `setup` appears to configure, but not fully enable coverage gathering, whereas `start` does both. Since Ruzzy doesn't need the builtin coverage information (we're adding our own hook), I thought performance would be better without the unnecessary builtin coverage hooks. But, you know what they say: make it work, make it correct, make it fast. I also didn't have any benchmarks to confirm this hypothesis, so who knows how this actually affected performance 🤷 